### PR TITLE
[FIX] Migrate tmc test decorators to Odoo 19 syntax

### DIFF
--- a/tmc/security/groups.xml
+++ b/tmc/security/groups.xml
@@ -6,30 +6,59 @@
         <field name="sequence">1</field>
     </record>
 
+    <!-- EPIC-015/TASK-005: privilegio para los 3 grupos de ROL de GD. Sin esto los
+         grupos caian en "Extra Rights" (checkboxes sueltos, sin nombre de modulo) en
+         vez de un dropdown de rol como me/junco/raa.
+         Solo van los 3 roles: group_personal y group_hidden_elements son MODIFICADORES
+         (personal implica group_user) y el privilegio es un select excluyente, asi que
+         meterlos los volveria incompatibles con User/Manager. -->
+    <record id="res_groups_privilege_tmc"
+        model="res.groups.privilege">
+        <field name="name">GD</field>
+        <field name="category_id" ref="module_category_tmc" />
+    </record>
+
+    <!-- EPIC-015/TASK-005: los records van en el ORDEN DE LA ESCALERA
+         (Read Only -> User -> Manager) y cada escalon implica al anterior.
+         1. Tecnico: ref('group_read_only') no resuelve si el record todavia no
+            existe -> con el orden viejo (user primero) el modulo no carga.
+         2. El orden del dropdown lo decide (rank, sequence, id) en res_groups.py,
+            rank = len(all_implied_ids & grupos del privilegio). Con la cadena real
+            el rank es 1/2/3 y el orden es ESTRUCTURAL; sin ella User y Read Only
+            empatan y desempata el id (accidente numerico) -> el widget
+            (res_user_group_ids_field.js) borra opciones del dropdown. -->
+
+    <record id="group_read_only"
+        model="res.groups">
+        <field name="name">Read Only</field>
+        <field name="privilege_id" ref="res_groups_privilege_tmc" />
+    </record>
+
     <record id="group_user"
         model="res.groups">
         <field name="name">User</field>
+        <field name="privilege_id" ref="res_groups_privilege_tmc" />
+        <!-- implica group_read_only para que la escalera sea cadena real (rank 2).
+             base.group_user explicito: group_read_only no lo encadena. -->
         <field name="implied_ids"
-            eval="[(4, ref('base.group_user'))]" />
+            eval="[(4, ref('base.group_user')), (4, ref('group_read_only'))]" />
     </record>
 
     <record id="group_manager"
         model="res.groups">
         <field name="name">Manager</field>
+        <field name="privilege_id" ref="res_groups_privilege_tmc" />
         <field name="implied_ids"
-            eval="[(4,ref('group_user'))]" />
+            eval="[(4, ref('group_user'))]" />
     </record>
 
+    <!-- Modificadores: NO llevan privilege_id (no son roles). Quedan como checkboxes
+         en "Extra Rights", que es lo que son. -->
     <record id="group_personal"
         model="res.groups">
         <field name="name">Personal</field>
         <field name="implied_ids"
             eval="[(4,ref('group_user'))]" />
-    </record>
-
-    <record id="group_read_only"
-        model="res.groups">
-        <field name="name">Read Only</field>
     </record>
 
     <record id="group_hidden_elements"

--- a/tmc/tests/__init__.py
+++ b/tmc/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_document
+from . import test_security

--- a/tmc/tests/test_document.py
+++ b/tmc/tests/test_document.py
@@ -1,8 +1,7 @@
-from odoo.tests import common
+from odoo.tests import common, tagged
 
 
-@common.at_install(False)
-@common.post_install(True)
+@tagged('post_install', '-at_install')
 class TestDocument(common.TransactionCase):
     def test_create(self):
         Documents = self.env["tmc.document"]

--- a/tmc/tests/test_security.py
+++ b/tmc/tests/test_security.py
@@ -1,0 +1,47 @@
+from odoo.tests import common, tagged
+
+
+@tagged('post_install', '-at_install')
+class TestTmcSecurity(common.TransactionCase):
+    # EPIC-015/TASK-005 — el orden de la escalera del privilegio GD debe ser
+    # ESTRUCTURAL (Read Only -> User -> Manager por implicacion), no producto del
+    # desempate por id de res_groups.py (rank, sequence, id).
+    #
+    # Si esto se rompe, el widget de permisos (res_user_group_ids_field.js) borra
+    # las opciones de MENOR nivel cuando una superior esta implicada, y el dropdown
+    # deja de ofrecer roles asignables. Fue el defecto de TASK-004 en ME y JUNCO:
+    # ninguna suite lo vio, lo encontro una persona mirando un dropdown.
+    #
+    # NO relajar a "los 3 grupos estan presentes": el bug NO era ausencia sino ORDEN.
+    # El assert de ranks estrictamente crecientes es a proposito: falla tambien si
+    # alguien "arregla" el orden con sequence en vez de la cadena de implicacion.
+    def test_privilege_ladder_order_is_structural(self):
+        privilege = self.env.ref('tmc.res_groups_privilege_tmc')
+        read_only = self.env.ref('tmc.group_read_only')
+        user = self.env.ref('tmc.group_user')
+        manager = self.env.ref('tmc.group_manager')
+
+        hierarchy = self.env['res.groups']._get_view_group_hierarchy()
+        group_ids = hierarchy['privileges'][privilege.id]['group_ids']
+        self.assertEqual(
+            group_ids, [read_only.id, user.id, manager.id],
+            "la escalera GD debe ser Read Only -> User -> Manager",
+        )
+
+        ranks = [
+            len(self.env['res.groups'].browse(gid).all_implied_ids & privilege.group_ids)
+            for gid in group_ids
+        ]
+        self.assertEqual(
+            ranks, [1, 2, 3],
+            "el orden debe salir del rank (cadena real), no de sequence/id",
+        )
+
+    # Personal y Hidden Elements son MODIFICADORES, no roles: no deben entrar al
+    # privilegio (el select excluyente los volveria incompatibles con User/Manager).
+    def test_modifier_groups_have_no_privilege(self):
+        for xmlid in ('tmc.group_personal', 'tmc.group_hidden_elements'):
+            self.assertFalse(
+                self.env.ref(xmlid).privilege_id,
+                "%s es un modificador, no debe tener privilege_id" % xmlid,
+            )

--- a/tmc/views/tmc_menus.xml
+++ b/tmc/views/tmc_menus.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
 
+    <!-- EPIC-015/TASK-005: se suma tmc.group_read_only para que los lectores de GD
+         (los operativos de ME/JUNCO lo son por herencia, BR-016) vean la app.
+         Con la cadena de groups.xml alcanzaria read_only solo; se dejan los 4
+         explicitos por claridad. -->
     <menuitem id="tmc_menu"
         name="Gestión Documental"
         sequence="5"
-        groups="tmc.group_user,tmc.group_manager,base.group_system" />
+        groups="tmc.group_read_only,tmc.group_user,tmc.group_manager,base.group_system" />
 
     <menuitem id="tmc_others_menu"
         name="»"


### PR DESCRIPTION
- Replace deprecated @common.at_install(False) / @common.post_install(True) with @tagged('post_install', '-at_install')

