### PR TITLE
[FIX] Use fixed lower bound in institutional classifier period selection

### DIFF
--- a/tmc/models/institutional_classifier.py
+++ b/tmc/models/institutional_classifier.py
@@ -13,17 +13,11 @@ class InstitutionalClassifier(models.Model):
 
     display_name = fields.Char(compute="_compute_display_name", string="Name")
 
+    # Fixed lower bound: a rolling window invalidates seeded records over time
     period = fields.Selection(
         selection=[
             (str(num), str(num))
-            for num in reversed(
-                list(
-                    range(
-                        ((datetime.now().year) - 10),
-                        ((datetime.now().year) + 1),
-                    )
-                )
-            )
+            for num in reversed(range(2015, datetime.now().year + 1))
         ],
         required=True,
     )


### PR DESCRIPTION
## Problem

The `period` selection in `tmc.institutional_classifier` is built from a rolling 10-year window (`current year - 10` to `current year`). Seeded records eventually fall outside the valid options: in 2026 the window became 2016–2026, so the 2015 record shipped by `tmc_data` no longer matched any option and module updates failed with:

```
odoo.tools.convert.ParseError: while parsing .../tmc_data/data/tmc/institutional_classifier.xml:46
ValueError: Wrong value for tmc.institutional_classifier.period: '2015'
```

Left as is, the 2016 record would break in 2027, and so on each year.

## Fix

Pin the selection's lower bound to 2015 — the oldest period seeded by `tmc_data` — so historical records stay valid regardless of the current year.

## Verification

Ran `-u tmc_data` on a dev copy of the production database: `institutional_classifier.xml` loads cleanly and login works again.