### PR TITLE
[ADD] SUMAR menu under decentralized entities

### DIFF
--- a/tmc/views/document_menus.xml
+++ b/tmc/views/document_menus.xml
@@ -220,6 +220,12 @@
         sequence="30"
         action="document_action_form_spv" />
 
+    <menuitem id="tmc_menu_dependence_documents_entes_sumar"
+        name="SUMAR"
+        parent="tmc_menu_dependence_documents_entes"
+        sequence="32"
+        action="document_action_form_sumar" />
+
     <menuitem id="tmc_menu_dependence_documents_entes_ter"
         name="Terminal de Ómnibus"
         parent="tmc_menu_dependence_documents_entes"

--- a/tmc/views/document_views.xml
+++ b/tmc/views/document_views.xml
@@ -1611,6 +1611,48 @@
         </field>
     </record>
 
+    <!-- RESOLUCION SUMAR -->
+    <!-- SEARCH VIEW -->
+    <record id="document_sumar_simple_view_search"
+        model="ir.ui.view">
+        <field name="name">tmc.document.sumar.simple.view.search</field>
+        <field name="model">tmc.document</field>
+        <field name="arch"
+            type="xml">
+            <search>
+                <field name="number" />
+                <field name="period" />
+                <field name="document_object" />
+                <field name="document_type_id" />
+                <field name="main_topic_ids" />
+                <field name="secondary_topic_ids" />
+                <searchpanel>
+                    <field name="main_topic_ids"
+                        select="multi"
+                        enable_counters="1"
+                        icon="fa-tags"
+                        domain="[('dependence_ids', 'ilike', 'Servicio Urbano de Mantenimiento Ambiental Rosario')]" />
+                </searchpanel>
+            </search>
+        </field>
+    </record>
+    <!-- WINDOW ACTION -->
+    <record id="document_action_form_sumar"
+        model="ir.actions.act_window">
+        <field name="name">Servicio Urbano de Mantenimiento Ambiental Rosario (SUMAR)</field>
+        <field name="res_model">tmc.document</field>
+        <field name="view_mode">tree,form</field>
+        <field name="search_view_id"
+            ref="document_sumar_simple_view_search" />
+        <field name="domain">[('dependence_id', 'ilike', 'Servicio Urbano de Mantenimiento Ambiental Rosario')]</field>
+        <field name="help"
+            type="html">
+            <p class="o_view_nocontent_smiling_face">
+                No hay documentos para mostrar.
+            </p>
+        </field>
+    </record>
+
     <!-- CONCEJO -->
     <!-- SEARCH VIEW -->
     <record id="document_cm_simple_view_search"


### PR DESCRIPTION
## What

Add **SUMAR** (Servicio Urbano de Mantenimiento Ambiental Rosario) to the *Entes Descentralizados* menu:

- Menu item `tmc_menu_dependence_documents_entes_sumar` (sequence 32, alphabetical between SPVyH and Terminal de Ómnibus)
- Window action `document_action_form_sumar`
- Search view `document_sumar_simple_view_search` with the same topics searchpanel as the sibling entities

## Note on the action domain

The action domain uses `ilike` instead of the exact-name match used by sibling actions. The dependence record was renamed in production (the seeded `tmc_data` record is `noupdate`) and now carries a "(SUMAR)" suffix, so an exact match on the seeded name returns no documents. `ilike` matches the name with or without the suffix.

## Verification

Ran `-u tmc` on a dev copy of the production database: the menu shows up in the right position and the action returns the 88 existing SUMAR documents with their topics in the searchpanel.